### PR TITLE
Add release management tools and resources to MCP server

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import sys
 
 from fastmcp import FastMCP
@@ -7,6 +6,7 @@ from fastmcp import FastMCP
 from debt import debt_mcp
 from services import service_mcp
 from teams import teams_mcp
+from releases import release_mcp
 
 mcp = FastMCP("Service Map MCP")
 
@@ -21,6 +21,7 @@ async def setup():
     await mcp.import_server(debt_mcp)
     await mcp.import_server(teams_mcp)
     await mcp.import_server(service_mcp)
+    await mcp.import_server(release_mcp)
 
 
 def main():

--- a/src/releases.py
+++ b/src/releases.py
@@ -1,0 +1,42 @@
+from fastmcp import FastMCP
+
+from api_calls import api_caller
+
+release_mcp = FastMCP("Releases MCP")
+
+
+@release_mcp.prompt('get_releases')
+def prompt_get_releases(start: str, end: str) -> str:
+    """
+    Get a list of releases between two dates
+    :param start: start date in the format YYYY-MM-DD
+    :param end: end date in the format YYYY-MM-DD
+    :return: string prompt
+    """
+    return f"""
+        To get a list of all releases between two dates, use the tool `get_releases` or the resource `serviceatlas://releases/{start}/{end}`.
+        If you wish to search for releases today, the end date will need to have a value of tomorrow. The return object will be 
+        an array of release objects, with a service name, service id, version, and release date.
+    """
+
+
+@release_mcp.resource(uri='serviceatlas://releases/{start}/{end}', name='Get Releases in Date Range', mime_type='application/json')
+def get_releases_resource(start: str, end: str) -> list:
+    """
+    Get a list of releases between two dates. Start date is inclusive, while the end date is an exclusive
+    :param start: start date in the format YYYY-MM-DD (inclusive)
+    :param end: end date in the format YYYY-MM-DD (exclusive)
+    :return: list of releases
+    """
+    return api_caller.call_get(f'/releases/{start}/{end}')
+
+
+@release_mcp.tool(annotations={'readOnlyHint': True, 'title': 'Get Releases in Date Range'})
+def get_releases(start: str, end: str) -> list:
+    """
+    Get a list of releases between two dates. Start date is inclusive, while the end date is an exclusive
+    :param start: start date in the format YYYY-MM-DD (inclusive)
+    :param end: end date in the format YYYY-MM-DD (exclusive)
+    :return: list of releases
+    """
+    return api_caller.call_get(f'/releases/{start}/{end}')


### PR DESCRIPTION
Introduce tools (`get_releases`) and resources (`serviceatlas://releases/{start}/{end}`) for managing release data. Register `release_mcp` in MCP server setup. Optimize imports.

## Description

<!-- Provide a short description of what this PR is changing -->
### Code Rabbit Summary
<!-- This section allows Code Rabbit to generate a summary -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to retrieve releases within a specified date range, enabling users to filter release data by start and end dates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Fixes
<!-- Add any issues that this PR closes here -->
Closes #7 

## Post Deployment Tasks?
