### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/service-atlas/mcp/security/code-scanning/1](https://github.com/service-atlas/mcp/security/code-scanning/1)

To fix the problem, add a `permissions:` block restricting permissions of the GITHUB_TOKEN at the earliest possible scope. Since this workflow is only reading code and running tests, the correct minimal permission is `contents: read`. Add the following block either at the root of the workflow (to apply to all jobs) or, if more granular control is needed, under specific jobs; here, adding it just above `jobs:` at the root is best. This change requires editing the `.github/workflows/tests.yml` file and inserting:

```yaml
permissions:
  contents: read
```

above the `jobs:` key (after `on:`). No additional imports or logic are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to refine permission settings.

---

**Note:** This release contains infrastructure updates with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->